### PR TITLE
Fix test_json_serializes

### DIFF
--- a/kombu_fernet/serializers/__init__.py
+++ b/kombu_fernet/serializers/__init__.py
@@ -42,3 +42,5 @@ def force_text(func):
     def inner(message):
         if isinstance(message, six.binary_type):
             message = message.decode('utf-8')
+        return func(message)
+    return inner


### PR DESCRIPTION
Fix for unit tests to be runned on:
Python 3.4.0
Django 1.11.16

The modifications are necessary to prove that tests work on the new environment.